### PR TITLE
Androidx Biometrics code review

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name="androidx.biometric.DeviceCredentialHandlerActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/androidx/biometric/AuthenticationEvent.java
+++ b/app/src/main/java/androidx/biometric/AuthenticationEvent.java
@@ -44,9 +44,14 @@ abstract class AuthenticationEvent {
         }
     }
 
-    //Marker of a terminal state
-    static final class Complete extends AuthenticationEvent {
-        Complete() {
+    static final class Cancel extends AuthenticationEvent {
+        Cancel() {
+        }
+    }
+
+    //Marker of a consumed event
+    static final class Consumed extends AuthenticationEvent {
+        Consumed() {
         }
     }
 }

--- a/app/src/main/java/androidx/biometric/AuthenticationEvent.java
+++ b/app/src/main/java/androidx/biometric/AuthenticationEvent.java
@@ -1,3 +1,19 @@
+/*
+        Copyright 2020 Dmytro Saviuk
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
 package androidx.biometric;
 
 import androidx.annotation.NonNull;

--- a/app/src/main/java/androidx/biometric/AuthenticationEvent.java
+++ b/app/src/main/java/androidx/biometric/AuthenticationEvent.java
@@ -1,0 +1,52 @@
+package androidx.biometric;
+
+import androidx.annotation.NonNull;
+
+abstract class AuthenticationEvent {
+
+    private AuthenticationEvent() {
+    }
+
+    static final class Error extends AuthenticationEvent {
+        private final int errorCode;
+        private final CharSequence errorMessage;
+
+        Error(int errorCode, @NonNull CharSequence errorMessage) {
+            this.errorCode = errorCode;
+            this.errorMessage = errorMessage;
+        }
+
+        @NonNull
+        CharSequence getErrorMessage() {
+            return errorMessage;
+        }
+
+        int getErrorCode() {
+            return errorCode;
+        }
+    }
+
+    static final class Success extends AuthenticationEvent {
+        private final BiometricPrompt.AuthenticationResult result;
+
+        Success(@NonNull BiometricPrompt.AuthenticationResult result) {
+            this.result = result;
+        }
+
+        @NonNull
+        BiometricPrompt.AuthenticationResult getResult() {
+            return result;
+        }
+    }
+
+    static final class Failure extends AuthenticationEvent {
+        Failure() {
+        }
+    }
+
+    //Marker of a terminal state
+    static final class Complete extends AuthenticationEvent {
+        Complete() {
+        }
+    }
+}

--- a/app/src/main/java/androidx/biometric/BiometricFragment.java
+++ b/app/src/main/java/androidx/biometric/BiometricFragment.java
@@ -283,6 +283,7 @@ public class BiometricFragment extends Fragment {
                 mHandler.postDelayed(new Runnable() {
                     @Override
                     public void run() {
+                        // Ugh...
                         // Hack almost over 9000, ignore cancel signal if it's within the first
                         // quarter second.
                         mStartRespectingCancel = true;

--- a/app/src/main/java/androidx/biometric/BiometricFragment.java
+++ b/app/src/main/java/androidx/biometric/BiometricFragment.java
@@ -17,7 +17,6 @@
 package androidx.biometric;
 
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Build;
 import android.os.Bundle;
@@ -57,9 +56,6 @@ public class BiometricFragment extends Fragment {
 
     private static final String TAG = "BiometricFragment";
 
-    // Re-set in onAttach
-    private Context mContext;
-
     // Set whenever the support library's authenticate is called.
     private Bundle mBundle;
 
@@ -82,6 +78,7 @@ public class BiometricFragment extends Fragment {
     private boolean mStartRespectingCancel;
 
     // Do not rely on the application's executor when calling into the framework's code.
+    //TODO amazing, so why do you guys rely on it in FingerprintHelperFragment?
     private final Handler mHandler = new Handler(Looper.getMainLooper());
     private final Executor mExecutor = new Executor() {
         @Override
@@ -104,8 +101,8 @@ public class BiometricFragment extends Fragment {
                             public void run() {
                                 CharSequence error = errString;
                                 if (error == null) {
-                                    error = mContext.getString(R.string.default_error_msg) + " "
-                                            + errorCode;
+                                    error = getContext() != null ? getString(R.string.default_error_msg) + " "
+                                            + errorCode : "";
                                 }
                                 mClientAuthenticationCallback
                                         .onAuthenticationError(Utils.isUnknownError(errorCode)
@@ -250,12 +247,6 @@ public class BiometricFragment extends Fragment {
     boolean isDeviceCredentialAllowed() {
         return mBundle != null
                 && mBundle.getBoolean(BiometricPrompt.KEY_ALLOW_DEVICE_CREDENTIAL, false);
-    }
-
-    @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
-        mContext = context;
     }
 
     @Override

--- a/app/src/main/java/androidx/biometric/BiometricManager.java
+++ b/app/src/main/java/androidx/biometric/BiometricManager.java
@@ -88,7 +88,7 @@ public class BiometricManager {
     /** @return A {@link BiometricManager} instance with the provided context. */
     @NonNull
     public static BiometricManager from(@NonNull Context context) {
-        return new BiometricManager(context);
+        return new BiometricManager(context.getApplicationContext());
     }
 
     @SuppressWarnings("deprecation")

--- a/app/src/main/java/androidx/biometric/BiometricPrompt.java
+++ b/app/src/main/java/androidx/biometric/BiometricPrompt.java
@@ -441,13 +441,6 @@ public class BiometricPrompt implements BiometricConstants {
     private final Executor mExecutor;
     private final AuthenticationCallback mAuthenticationCallback;
 
-    // Created internally for devices before P.
-    private FingerprintDialogFragment mFingerprintDialogFragment;
-    private FingerprintHelperFragment mFingerprintHelperFragment;
-
-    // Created internally for devices P and above.
-    private BiometricFragment mBiometricFragment;
-
     // In Q, we must ignore the first onPause if setDeviceCredentialAllowed is true, since
     // the Q implementation launches ConfirmDeviceCredentialActivity which is an activity and
     // puts the client app onPause.
@@ -469,19 +462,22 @@ public class BiometricPrompt implements BiometricConstants {
                     mExecutor.execute(new Runnable() {
                         @Override
                         public void run() {
-                            if (canUseBiometricFragment() && mBiometricFragment != null) {
+                            FingerprintDialogFragment fingerprintDialog = getFingerprintDialogFragment();
+                            FingerprintHelperFragment fingerprintHelper = getFingerprintHelperFragment();
+                            BiometricFragment biometricFragment = getBiometricFragment();
+                            if (canUseBiometricFragment() && biometricFragment != null) {
                                 final CharSequence errorText =
-                                        mBiometricFragment.getNegativeButtonText();
+                                        biometricFragment.getNegativeButtonText();
                                 mAuthenticationCallback.onAuthenticationError(
                                         ERROR_NEGATIVE_BUTTON, errorText != null ? errorText : "");
-                                mBiometricFragment.cleanup();
-                            } else if (mFingerprintDialogFragment != null
-                                    && mFingerprintHelperFragment != null) {
+                                biometricFragment.cleanup();
+                            } else if (fingerprintDialog != null
+                                    && fingerprintHelper != null) {
                                 final CharSequence errorText =
-                                        mFingerprintDialogFragment.getNegativeButtonText();
+                                        fingerprintDialog.getNegativeButtonText();
                                 mAuthenticationCallback.onAuthenticationError(
                                         ERROR_NEGATIVE_BUTTON, errorText != null ? errorText : "");
-                                mFingerprintHelperFragment.cancel(
+                                fingerprintHelper.cancel(
                                         FingerprintHelperFragment
                                                 .USER_CANCELED_FROM_NEGATIVE_BUTTON);
                             } else {
@@ -503,24 +499,27 @@ public class BiometricPrompt implements BiometricConstants {
                 if (DEBUG) Log.v(TAG, "onPause() not run while configuration is changing.");
                 return;
             }
+            FingerprintDialogFragment fingerprintDialog = getFingerprintDialogFragment();
+            FingerprintHelperFragment fingerprintHelper = getFingerprintHelperFragment();
+            BiometricFragment biometricFragment = getBiometricFragment();
 
-            if (canUseBiometricFragment() && mBiometricFragment != null) {
+            if (canUseBiometricFragment() && biometricFragment != null) {
                 // TODO(b/123378871): Fix behavior in R and remove this workaround.
                 // Ignore the first onPause if isDeviceCredentialAllowed is true, since
                 // the Q implementation launches ConfirmDeviceCredentialActivity, which puts
                 // the client app onPause. Implementations prior to Q instead launch
                 // DeviceCredentialHandlerActivity, resulting in the same problem.
-                if (mBiometricFragment.isDeviceCredentialAllowed()) {
+                if (biometricFragment.isDeviceCredentialAllowed()) {
                     if (!mPausedOnce) {
                         mPausedOnce = true;
                     } else {
-                        mBiometricFragment.cancel();
+                        biometricFragment.cancel();
                     }
                 } else {
-                    mBiometricFragment.cancel();
+                    biometricFragment.cancel();
                 }
-            } else if (mFingerprintDialogFragment != null && mFingerprintHelperFragment != null) {
-                dismissFingerprintFragments(mFingerprintDialogFragment, mFingerprintHelperFragment);
+            } else if (fingerprintDialog != null && fingerprintHelper != null) {
+                dismissFingerprintFragments(fingerprintDialog, fingerprintHelper);
             }
 
             maybeResetHandlerBridge();
@@ -528,34 +527,33 @@ public class BiometricPrompt implements BiometricConstants {
 
         @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
         void onResume() {
-            mBiometricFragment = canUseBiometricFragment()
-                    ? (BiometricFragment) getFragmentManager().findFragmentByTag(
-                            BIOMETRIC_FRAGMENT_TAG)
+            FingerprintDialogFragment fingerprintDialog;
+            FingerprintHelperFragment fingerprintHelper;
+            BiometricFragment biometricFragment;
+
+            biometricFragment = canUseBiometricFragment()
+                    ? getBiometricFragment()
                     : null;
             if (DEBUG && canUseBiometricFragment()) {
-                Log.v(TAG, "BiometricFragment: " + mBiometricFragment);
+                Log.v(TAG, "BiometricFragment: " + biometricFragment);
             }
-            if (canUseBiometricFragment() && mBiometricFragment != null) {
-                mBiometricFragment.setCallbacks(mExecutor, mNegativeButtonListener,
+            if (canUseBiometricFragment() && biometricFragment != null) {
+                biometricFragment.setCallbacks(mExecutor, mNegativeButtonListener,
                         mAuthenticationCallback);
             } else {
-                mFingerprintDialogFragment =
-                        (FingerprintDialogFragment) getFragmentManager().findFragmentByTag(
-                                DIALOG_FRAGMENT_TAG);
-                mFingerprintHelperFragment =
-                        (FingerprintHelperFragment) getFragmentManager().findFragmentByTag(
-                                FINGERPRINT_HELPER_FRAGMENT_TAG);
+                fingerprintDialog = getFingerprintDialogFragment();
+                fingerprintHelper = getFingerprintHelperFragment();
 
-                if (DEBUG) Log.v(TAG, "FingerprintDialogFragment: " + mFingerprintDialogFragment);
-                if (DEBUG) Log.v(TAG, "FingerprintHelperFragment: " + mFingerprintHelperFragment);
-                if (mFingerprintDialogFragment != null) {
-                    mFingerprintDialogFragment.setNegativeButtonListener(mNegativeButtonListener);
+                if (DEBUG) Log.v(TAG, "FingerprintDialogFragment: " + fingerprintDialog);
+                if (DEBUG) Log.v(TAG, "FingerprintHelperFragment: " + fingerprintHelper);
+                if (fingerprintDialog != null) {
+                    fingerprintDialog.setNegativeButtonListener(mNegativeButtonListener);
                 }
-                if (mFingerprintHelperFragment != null) {
-                    mFingerprintHelperFragment.setExecutor(mExecutor);
-                    if (mFingerprintDialogFragment != null) {
-                        mFingerprintHelperFragment.setHandler(
-                                mFingerprintDialogFragment.getHandler());
+                if (fingerprintHelper != null) {
+                    fingerprintHelper.setExecutor(mExecutor);
+                    if (fingerprintDialog != null) {
+                        fingerprintHelper.setHandler(
+                                fingerprintDialog.getHandler());
                     }
                 }
             }
@@ -717,68 +715,66 @@ public class BiometricPrompt implements BiometricConstants {
                         activity, Build.MANUFACTURER, Build.MODEL));
 
         if (!shouldForceFingerprint && canUseBiometricFragment()) {
-            BiometricFragment biometricFragment =
-                    (BiometricFragment) fragmentManager.findFragmentByTag(BIOMETRIC_FRAGMENT_TAG);
-            if (biometricFragment != null) {
-                mBiometricFragment = biometricFragment;
+            BiometricFragment existingBiometricFragment = getBiometricFragment();
+            BiometricFragment biometricFragment;
+            if (existingBiometricFragment != null) {
+                biometricFragment = existingBiometricFragment;
             } else {
-                mBiometricFragment = BiometricFragment.newInstance();
+                biometricFragment = BiometricFragment.newInstance();
             }
-            mBiometricFragment.setCallbacks(mExecutor, mNegativeButtonListener,
+            biometricFragment.setCallbacks(mExecutor, mNegativeButtonListener,
                     mAuthenticationCallback);
 
             // Set the crypto object.
-            mBiometricFragment.setCryptoObject(crypto);
-            mBiometricFragment.setBundle(bundle);
+            biometricFragment.setCryptoObject(crypto);
+            biometricFragment.setBundle(bundle);
 
-            if (biometricFragment == null) {
+            if (existingBiometricFragment == null) {
                 // If the fragment hasn't been added before, add it. It will also start the
                 // authentication.
-                fragmentManager.beginTransaction().add(mBiometricFragment, BIOMETRIC_FRAGMENT_TAG)
+                fragmentManager.beginTransaction().add(biometricFragment, BIOMETRIC_FRAGMENT_TAG)
                         .commitAllowingStateLoss();
-            } else if (mBiometricFragment.isDetached()) {
+            } else if (biometricFragment.isDetached()) {
                 // If it's been added before, just re-attach it.
-                fragmentManager.beginTransaction().attach(mBiometricFragment)
+                fragmentManager.beginTransaction().attach(biometricFragment)
                         .commitAllowingStateLoss();
             }
         } else {
             // Create the UI
-            FingerprintDialogFragment fingerprintDialogFragment =
-                    (FingerprintDialogFragment) fragmentManager.findFragmentByTag(
-                            DIALOG_FRAGMENT_TAG);
+            FingerprintDialogFragment fingerprintDialogFragment = getFingerprintDialogFragment();
+            FingerprintDialogFragment fingerprintDialog;
             if (fingerprintDialogFragment != null) {
-                mFingerprintDialogFragment = fingerprintDialogFragment;
+                fingerprintDialog = fingerprintDialogFragment;
             } else {
-                mFingerprintDialogFragment = FingerprintDialogFragment.newInstance();
+                fingerprintDialog = FingerprintDialogFragment.newInstance();
             }
 
-            mFingerprintDialogFragment.setNegativeButtonListener(mNegativeButtonListener);
-            mFingerprintDialogFragment.setBundle(bundle);
+            fingerprintDialog.setNegativeButtonListener(mNegativeButtonListener);
+            fingerprintDialog.setBundle(bundle);
 
             if (activity != null && !Utils.shouldHideFingerprintDialog(activity, Build.MODEL)) {
                 if (fingerprintDialogFragment == null) {
-                    mFingerprintDialogFragment.show(fragmentManager, DIALOG_FRAGMENT_TAG);
-                } else if (mFingerprintDialogFragment.isDetached()) {
-                    fragmentManager.beginTransaction().attach(mFingerprintDialogFragment)
+                    fingerprintDialog.show(fragmentManager, DIALOG_FRAGMENT_TAG);
+                } else if (fingerprintDialog.isDetached()) {
+                    fragmentManager.beginTransaction().attach(fingerprintDialog)
                             .commitAllowingStateLoss();
                 }
             }
 
             // Create the connection to FingerprintManager
-            FingerprintHelperFragment fingerprintHelperFragment =
-                    (FingerprintHelperFragment) fragmentManager.findFragmentByTag(
-                            FINGERPRINT_HELPER_FRAGMENT_TAG);
+            FingerprintHelperFragment fingerprintHelperFragment = getFingerprintHelperFragment();
+            FingerprintHelperFragment fingerprintHelper;
             if (fingerprintHelperFragment != null) {
-                mFingerprintHelperFragment = fingerprintHelperFragment;
+                fingerprintHelper = fingerprintHelperFragment;
             } else {
-                mFingerprintHelperFragment = FingerprintHelperFragment.newInstance();
+                fingerprintHelper = FingerprintHelperFragment.newInstance();
             }
 
-            mFingerprintHelperFragment.setExecutor(mExecutor);
-            observeAuthenticationResults();
-            final Handler fingerprintDialogHandler = mFingerprintDialogFragment.getHandler();
-            mFingerprintHelperFragment.setHandler(fingerprintDialogHandler);
-            mFingerprintHelperFragment.setCryptoObject(crypto);
+            fingerprintHelper.setExecutor(mExecutor);
+            observeAuthenticationResults(fingerprintDialog, fingerprintHelper);
+            final Handler fingerprintDialogHandler = fingerprintDialog.getHandler();
+            fingerprintHelper.setHandler(fingerprintDialogHandler);
+            fingerprintHelper.setCryptoObject(crypto);
             fingerprintDialogHandler.sendMessageDelayed(
                     fingerprintDialogHandler.obtainMessage(
                             FingerprintDialogFragment.DISPLAYED_FOR_500_MS), DELAY_MILLIS);
@@ -787,11 +783,11 @@ public class BiometricPrompt implements BiometricConstants {
                 // If the fragment hasn't been added before, add it. It will also start the
                 // authentication.
                 fragmentManager.beginTransaction()
-                        .add(mFingerprintHelperFragment, FINGERPRINT_HELPER_FRAGMENT_TAG)
+                        .add(fingerprintHelper, FINGERPRINT_HELPER_FRAGMENT_TAG)
                         .commitAllowingStateLoss();
-            } else if (mFingerprintHelperFragment.isDetached()) {
+            } else if (fingerprintHelper.isDetached()) {
                 // If it's been added before, just re-attach it.
-                fragmentManager.beginTransaction().attach(mFingerprintHelperFragment)
+                fragmentManager.beginTransaction().attach(fingerprintHelper)
                         .commitAllowingStateLoss();
             }
         }
@@ -801,8 +797,9 @@ public class BiometricPrompt implements BiometricConstants {
         fragmentManager.executePendingTransactions();
     }
 
-    private void observeAuthenticationResults() {
-        mFingerprintHelperFragment.getAuthenticationEvents().observe(mFingerprintDialogFragment, new Observer<AuthenticationEvent>() {
+    private void observeAuthenticationResults(FingerprintDialogFragment fingerprintDialog,
+                                              FingerprintHelperFragment fingerprintHelper) {
+        fingerprintHelper.getAuthenticationEvents().observe(fingerprintDialog, new Observer<AuthenticationEvent>() {
             @Override
             public void onChanged(AuthenticationEvent authenticationEvent) {
                 if (authenticationEvent instanceof AuthenticationEvent.Success) {
@@ -827,11 +824,15 @@ public class BiometricPrompt implements BiometricConstants {
      * details.
      */
     public void cancelAuthentication() {
-        if (canUseBiometricFragment() && mBiometricFragment != null) {
-            mBiometricFragment.cancel();
+        FingerprintDialogFragment fingerprintDialog = getFingerprintDialogFragment();
+        FingerprintHelperFragment fingerprintHelper = getFingerprintHelperFragment();
+        BiometricFragment biometricFragment = getBiometricFragment();
 
-            if (mFingerprintHelperFragment != null && mFingerprintDialogFragment != null) {
-                dismissFingerprintFragments(mFingerprintDialogFragment, mFingerprintHelperFragment);
+        if (canUseBiometricFragment() && biometricFragment != null) {
+            biometricFragment.cancel();
+
+            if (fingerprintHelper != null && fingerprintDialog != null) {
+                dismissFingerprintFragments(fingerprintDialog, fingerprintHelper);
             }
         }
     }
@@ -886,12 +887,16 @@ public class BiometricPrompt implements BiometricConstants {
         }
 
         bridge.setCallbacks(mExecutor, mAuthenticationCallback);
-        if (mBiometricFragment != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            mBiometricFragment.setCallbacks(mExecutor, mNegativeButtonListener, mAuthenticationCallback);
-        } else if (mFingerprintDialogFragment != null && mFingerprintHelperFragment != null) {
-            mFingerprintDialogFragment.setNegativeButtonListener(mNegativeButtonListener);
-            mFingerprintHelperFragment.setExecutor(mExecutor);
-            mFingerprintHelperFragment.setHandler(mFingerprintDialogFragment.getHandler());
+        FingerprintDialogFragment fingerprintDialog = getFingerprintDialogFragment();
+        FingerprintHelperFragment fingerprintHelper = getFingerprintHelperFragment();
+        BiometricFragment biometricFragment = getBiometricFragment();
+
+        if (biometricFragment != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            biometricFragment.setCallbacks(mExecutor, mNegativeButtonListener, mAuthenticationCallback);
+        } else if (fingerprintDialog != null && fingerprintHelper != null) {
+            fingerprintDialog.setNegativeButtonListener(mNegativeButtonListener);
+            fingerprintHelper.setExecutor(mExecutor);
+            fingerprintHelper.setHandler(fingerprintDialog.getHandler());
         }
 
         if (startIgnoringReset) {
@@ -962,6 +967,21 @@ public class BiometricPrompt implements BiometricConstants {
     private FragmentManager getFragmentManager() {
         return mFragmentActivity != null ? mFragmentActivity.getSupportFragmentManager()
                 : mFragment.getChildFragmentManager();
+    }
+
+    private FingerprintDialogFragment getFingerprintDialogFragment() {
+        return (FingerprintDialogFragment) getFragmentManager().findFragmentByTag(
+                DIALOG_FRAGMENT_TAG);
+    }
+
+    private FingerprintHelperFragment getFingerprintHelperFragment() {
+        return (FingerprintHelperFragment) getFragmentManager().findFragmentByTag(
+                FINGERPRINT_HELPER_FRAGMENT_TAG);
+    }
+
+    private BiometricFragment getBiometricFragment() {
+        return (BiometricFragment) getFragmentManager().findFragmentByTag(
+                BIOMETRIC_FRAGMENT_TAG);
     }
 
     /**

--- a/app/src/main/java/androidx/biometric/BiometricPrompt.java
+++ b/app/src/main/java/androidx/biometric/BiometricPrompt.java
@@ -724,7 +724,7 @@ public class BiometricPrompt implements BiometricConstants {
                 biometricFragment = BiometricFragment.newInstance();
             }
             biometricFragment.setCallbacks(mExecutor);
-            observeAuthenticationResults(biometricFragment.getAuthenticationEvents());
+            observeAuthenticationResults(biometricFragment.getAuthenticationEvents(), activity);
 
             // Set the crypto object.
             biometricFragment.setCryptoObject(crypto);
@@ -772,7 +772,7 @@ public class BiometricPrompt implements BiometricConstants {
             }
 
             fingerprintHelper.setExecutor(mExecutor);
-            observeAuthenticationResults(fingerprintHelper.getAuthenticationEvents());
+            observeAuthenticationResults(fingerprintHelper.getAuthenticationEvents(), activity);
             final Handler fingerprintDialogHandler = fingerprintDialog.getHandler();
             fingerprintHelper.setHandler(fingerprintDialogHandler);
             fingerprintHelper.setCryptoObject(crypto);
@@ -798,8 +798,8 @@ public class BiometricPrompt implements BiometricConstants {
         fragmentManager.executePendingTransactions();
     }
 
-    private void observeAuthenticationResults(LiveData<AuthenticationEvent> events) {
-        events.observe(getActivity(), new Observer<AuthenticationEvent>() {
+    private void observeAuthenticationResults(@NonNull LiveData<AuthenticationEvent> events, @NonNull FragmentActivity activity) {
+        events.observe(activity, new Observer<AuthenticationEvent>() {
             @Override
             public void onChanged(AuthenticationEvent authenticationEvent) {
                 if (authenticationEvent instanceof AuthenticationEvent.Success) {

--- a/app/src/main/java/androidx/biometric/DeviceCredentialHandlerActivity.java
+++ b/app/src/main/java/androidx/biometric/DeviceCredentialHandlerActivity.java
@@ -89,6 +89,7 @@ public class DeviceCredentialHandlerActivity extends AppCompatActivity {
         super.onPause();
 
         // Prevent the client from resetting the bridge in onPause if just changing configuration.
+        // JUST configuration change. lol
         final DeviceCredentialHandlerBridge bridge =
                 DeviceCredentialHandlerBridge.getInstanceIfNotNull();
         if (isChangingConfigurations() && bridge != null) {

--- a/app/src/main/java/androidx/biometric/DeviceCredentialHandlerBridge.java
+++ b/app/src/main/java/androidx/biometric/DeviceCredentialHandlerBridge.java
@@ -44,19 +44,7 @@ public class DeviceCredentialHandlerBridge {
     private int mClientThemeResId;
 
     @Nullable
-    private BiometricFragment mBiometricFragment;
-
-    @Nullable
-    private FingerprintDialogFragment mFingerprintDialogFragment;
-
-    @Nullable
-    private FingerprintHelperFragment mFingerprintHelperFragment;
-
-    @Nullable
     private Executor mExecutor;
-
-    @Nullable
-    private DialogInterface.OnClickListener mOnClickListener;
 
     @Nullable
     private BiometricPrompt.AuthenticationCallback mAuthenticationCallback;
@@ -118,82 +106,22 @@ public class DeviceCredentialHandlerBridge {
     }
 
     /**
-     * Registers a {@link BiometricFragment} to the bridge. This will automatically receive new
-     * callbacks set by {@link #setCallbacks(Executor, DialogInterface.OnClickListener,
-     * BiometricPrompt.AuthenticationCallback)}.
-     */
-    void setBiometricFragment(@Nullable BiometricFragment biometricFragment) {
-        mBiometricFragment = biometricFragment;
-    }
-
-    /** @return See {@link #setBiometricFragment(BiometricFragment)}. */
-    @Nullable
-    BiometricFragment getBiometricFragment() {
-        return mBiometricFragment;
-    }
-
-    /**
-     * Registers a {@link FingerprintDialogFragment} and {@link FingerprintHelperFragment} to the
-     * bridge. These will automatically receive new callbacks set by {@link #setCallbacks(Executor,
-     * DialogInterface.OnClickListener, BiometricPrompt.AuthenticationCallback)}.
-     */
-    void setFingerprintFragments(@Nullable FingerprintDialogFragment fingerprintDialogFragment,
-            @Nullable FingerprintHelperFragment fingerprintHelperFragment) {
-        mFingerprintDialogFragment = fingerprintDialogFragment;
-        mFingerprintHelperFragment = fingerprintHelperFragment;
-    }
-
-    /**
-     * @return The latest {@link FingerprintDialogFragment} set via
-     * {@link #setFingerprintFragments(FingerprintDialogFragment, FingerprintHelperFragment)}.
-     */
-    @Nullable
-    public FingerprintDialogFragment getFingerprintDialogFragment() {
-        return mFingerprintDialogFragment;
-    }
-
-    /**
-     * @return The latest {@link FingerprintHelperFragment} set via
-     * {@link #setFingerprintFragments(FingerprintDialogFragment, FingerprintHelperFragment)}.
-     */
-    @Nullable
-    public FingerprintHelperFragment getFingerprintHelperFragment() {
-        return mFingerprintHelperFragment;
-    }
-
-    /**
-     * Registers dialog and authentication callbacks to the bridge, along with an executor that can
+     * Registers authentication callbacks to the bridge, along with an executor that can
      * be used to run them.
      *
-     * <p>If a {@link BiometricFragment} has been registered via
-     * {@link #setBiometricFragment(BiometricFragment)}, or if a {@link FingerprintDialogFragment}
-     * and {@link FingerprintHelperFragment} have been registered via
-     * {@link #setFingerprintFragments(FingerprintDialogFragment, FingerprintHelperFragment)}, then
-     * these fragments will receive the updated executor and callbacks as well.
-     *
      * @param executor               An executor that can be used to run callbacks.
-     * @param onClickListener        A dialog button listener for a biometric prompt.
      * @param authenticationCallback A handler for various biometric prompt authentication events.
      */
     @SuppressLint("LambdaLast")
     void setCallbacks(@NonNull Executor executor,
-            @NonNull DialogInterface.OnClickListener onClickListener,
             @NonNull BiometricPrompt.AuthenticationCallback authenticationCallback) {
         mExecutor = executor;
-        mOnClickListener = onClickListener;
         mAuthenticationCallback = authenticationCallback;
-        if (mBiometricFragment != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            mBiometricFragment.setCallbacks(executor, onClickListener, authenticationCallback);
-        } else if (mFingerprintDialogFragment != null && mFingerprintHelperFragment != null) {
-            mFingerprintDialogFragment.setNegativeButtonListener(onClickListener);
-            mFingerprintHelperFragment.setCallback(executor, authenticationCallback);
-            mFingerprintHelperFragment.setHandler(mFingerprintDialogFragment.getHandler());
-        }
     }
 
     /**
      * @return The latest {@link Executor} set via {@link #setCallbacks(Executor,
-     * DialogInterface.OnClickListener, BiometricPrompt.AuthenticationCallback)}.
+     * BiometricPrompt.AuthenticationCallback)}.
      */
     @Nullable
     Executor getExecutor() {
@@ -201,17 +129,8 @@ public class DeviceCredentialHandlerBridge {
     }
 
     /**
-     * @return The latest {@link DialogInterface.OnClickListener} set via {@link #setCallbacks(
-     * Executor, DialogInterface.OnClickListener, BiometricPrompt.AuthenticationCallback)}.
-     */
-    @Nullable
-    DialogInterface.OnClickListener getOnClickListener() {
-        return mOnClickListener;
-    }
-
-    /**
      * @return The latest {@link BiometricPrompt.AuthenticationCallback} set via
-     * {@link #setCallbacks(Executor, DialogInterface.OnClickListener,
+     * {@link #setCallbacks(Executor,
      * BiometricPrompt.AuthenticationCallback)}.
      */
     @Nullable
@@ -290,11 +209,7 @@ public class DeviceCredentialHandlerBridge {
         }
 
         mClientThemeResId = 0;
-        mBiometricFragment = null;
-        mFingerprintDialogFragment = null;
-        mFingerprintHelperFragment = null;
         mExecutor = null;
-        mOnClickListener = null;
         mAuthenticationCallback = null;
         mDeviceCredentialResult = RESULT_NONE;
         mConfirmingDeviceCredential = false;

--- a/app/src/main/java/androidx/biometric/DeviceCredentialHandlerBridge.java
+++ b/app/src/main/java/androidx/biometric/DeviceCredentialHandlerBridge.java
@@ -179,6 +179,7 @@ public class DeviceCredentialHandlerBridge {
      * Indicates that the bridge should ignore all subsequent calls to {@link #reset} until
      * {@link #stopIgnoringReset()} is called.
      */
+    //Ugh...
     void startIgnoringReset() {
         mIgnoreResetState = IGNORING_RESET;
     }

--- a/app/src/main/java/androidx/biometric/FingerprintHelperFragment.java
+++ b/app/src/main/java/androidx/biometric/FingerprintHelperFragment.java
@@ -246,7 +246,7 @@ public class FingerprintHelperFragment extends Fragment {
             mCancellationSignal = new CancellationSignal();
             mCanceledFrom = USER_CANCELED_FROM_NONE;
             androidx.core.hardware.fingerprint.FingerprintManagerCompat fingerprintManagerCompat =
-                    androidx.core.hardware.fingerprint.FingerprintManagerCompat.from(requireContext());
+                    androidx.core.hardware.fingerprint.FingerprintManagerCompat.from(requireContext().getApplicationContext());
             if (handlePreAuthenticationErrors(fingerprintManagerCompat)) {
                 mMessageRouter.sendMessage(FingerprintDialogFragment.MSG_DISMISS_DIALOG_ERROR);
                 cleanup();

--- a/app/src/main/java/androidx/biometric/FingerprintHelperFragment.java
+++ b/app/src/main/java/androidx/biometric/FingerprintHelperFragment.java
@@ -33,9 +33,7 @@ import androidx.core.os.CancellationSignal;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MediatorLiveData;
 import androidx.lifecycle.MutableLiveData;
-import androidx.lifecycle.Observer;
 
 import com.eightbitlab.biometricbugs.R;
 
@@ -270,24 +268,7 @@ public class FingerprintHelperFragment extends Fragment {
     }
 
     LiveData<AuthenticationEvent> getAuthenticationEvents() {
-        MediatorLiveData<AuthenticationEvent> terminalEventMediator = new MediatorLiveData<>();
-
-        //MediatorLiveData makes sure that if onChanged is called, there's a consumer that
-        //received the event. If it's one of terminal events (Success/Error), we clear the LiveData
-        //cache so we don't repeat it next time the observer subscribes
-        terminalEventMediator.addSource(authenticationEvents, new Observer<AuthenticationEvent>() {
-            @Override
-            public void onChanged(AuthenticationEvent authenticationEvent) {
-                terminalEventMediator.setValue(authenticationEvent);
-                boolean terminalEvent = authenticationEvent instanceof AuthenticationEvent.Success ||
-                        authenticationEvent instanceof AuthenticationEvent.Error;
-
-                if (terminalEvent) {
-                    authenticationEvents.setValue(new AuthenticationEvent.Complete());
-                }
-            }
-        });
-        return terminalEventMediator;
+        return LiveDataExtensions.toConsumableEvents(authenticationEvents);
     }
 
     /**

--- a/app/src/main/java/androidx/biometric/LiveDataExtensions.java
+++ b/app/src/main/java/androidx/biometric/LiveDataExtensions.java
@@ -1,3 +1,19 @@
+/*
+        Copyright 2020 Dmytro Saviuk
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
 package androidx.biometric;
 
 import androidx.lifecycle.LiveData;

--- a/app/src/main/java/androidx/biometric/LiveDataExtensions.java
+++ b/app/src/main/java/androidx/biometric/LiveDataExtensions.java
@@ -1,0 +1,26 @@
+package androidx.biometric;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
+
+class LiveDataExtensions {
+    static LiveData<AuthenticationEvent> toConsumableEvents(MutableLiveData<AuthenticationEvent> authenticationEvents) {
+        MediatorLiveData<AuthenticationEvent> oneShotEventMediator = new MediatorLiveData<>();
+
+        //MediatorLiveData makes sure that if onChanged is called, there's a consumer that
+        //received the event. In this case, we clear the LiveData
+        //cache so we don't repeat it next time the observer subscribes.
+        oneShotEventMediator.addSource(authenticationEvents, new Observer<AuthenticationEvent>() {
+            @Override
+            public void onChanged(AuthenticationEvent authenticationEvent) {
+                oneShotEventMediator.setValue(authenticationEvent);
+                if (!(authenticationEvent instanceof AuthenticationEvent.Consumed)) {
+                    authenticationEvents.setValue(new AuthenticationEvent.Consumed());
+                }
+            }
+        });
+        return oneShotEventMediator;
+    }
+}

--- a/app/src/main/java/com/eightbitlab/biometricbugs/MainActivity.kt
+++ b/app/src/main/java/com/eightbitlab/biometricbugs/MainActivity.kt
@@ -1,3 +1,19 @@
+/*
+        Copyright 2020 Dmytro Saviuk
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
 package com.eightbitlab.biometricbugs
 
 import androidx.appcompat.app.AppCompatActivity


### PR DESCRIPTION
First, I'll describe on a high level how the library is structured and how the data flows here, so you'll have a more clear idea when reading the review comments. You can skip this if you have a general idea already or just want to get straight to the point.

There's a `BiometricPrompt` object. It's an entry point and user of the library passes to it their callbacks and Context, and asks for authentication.

`BiometricPrompt`, in its turn, is responsible for creating, setting up and removing Fragments (`FingerprintDialogFragment` and `FingerprintHelperFragment` before Android P and `BiometricFragment` on Android P+)

`FingerprintHelperFragment` is a headless (no UI) fragment that talks to `FingerprintManagerCompat` for authentication. 
After receiving auth callbacks, it talks to `FingerprintDialogFragment` through Handler. Here goes most of the UI work.

Prior to Android Q, there's also `DeviceCredentialHandlerActivity` that sort of handles the optional authentication through pin/password instead of biometrics.
Various data is passed there through a static singleton `DeviceCredentialHandlerBridge`, which is just a data (and leaks) holder.

On Android P+, `BiometricFragment` is used to communicate with system's `BiometricPrompt` (don't confuse it with library's `BiometricPrompt`) for authentication. There's no UI part here, as starting from Android P it's a OEM's responsibility to provide a UI fragment for biometric authentication, which is later called by the `BiometricPrompt`.

This is the main idea, but unfortunately, it is very poorly implemented.
See the comments, fixes and feel free to suggest some improvements!